### PR TITLE
Improve pipeline and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # chainIt
+
+High performance utilities for building flexible function pipelines. Steps can
+be decorated to enable JIT compilation with Numba, lightweight CFFI
+optimisation or automatic batching and parallel execution.
+
+## Installation
+
+```bash
+pip install chainit
+```
+
+## Usage
+
+```python
+from pipeline import piped, Pipeline
+
+@piped
+def double(x):
+    return x * 2
+
+pipeline = double
+print(pipeline.run(3))  # 6
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "chainit"
 version = "0.1.0"
-description = "Add your description here"
+description = "Lightweight pipeline utilities"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = ["numpy", "cffi"]
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
## Summary
- drop duplicate `_prepare_args`
- support FFI step compilation via `piped(cffi=True)`
- adjust integration and performance tests
- add edge case tests and update README
- add numpy and cffi to runtime dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868138666ac8327af3ba8da5dc4ea7c